### PR TITLE
Adding METNoMu, cut-based IDs for leptons

### DIFF
--- a/TTHAnalysis/cfg/run_susyDeDx_cfg.py
+++ b/TTHAnalysis/cfg/run_susyDeDx_cfg.py
@@ -28,6 +28,12 @@ jetAnaScaleUp.calculateType1METCorrection = True
 jetAnaScaleDown.calculateType1METCorrection = True
 
 ## early skimming on the isolated track
+from CMGTools.TTHAnalysis.analyzers.ttHFastJetSkimmer import ttHFastJetSkimmer
+fastJetSkim = cfg.Analyzer(ttHFastJetSkimmer, name="fastJetSkimmer",
+    jets = 'slimmedJets',
+    jetCut = lambda j : j.pt() > 80 and abs(j.eta()) < 2.4, # looser pt because of non-final JECs
+    minJets = 1,
+    )
 from CMGTools.TTHAnalysis.analyzers.isoTrackFastSkimmer import isoTrackFastSkimmer
 isoTrackFastSkim = cfg.Analyzer(isoTrackFastSkimmer, name="isoTrackFastSkim",
     cut = lambda t : (t.pt() > 50 and
@@ -90,6 +96,7 @@ sequence = cfg.Sequence( [
     jsonAna,
     triggerAna,
 
+    fastJetSkim,
     isoTrackFastSkim,
 
     genAna,

--- a/TTHAnalysis/cfg/run_susyDeDx_cfg.py
+++ b/TTHAnalysis/cfg/run_susyDeDx_cfg.py
@@ -9,59 +9,42 @@ from PhysicsTools.HeppyCore.framework.heppy_loop import getHeppyOption
 from CMGTools.RootTools.samples.configTools import *
 from CMGTools.RootTools.samples.autoAAAconfig import *
 
-#-------- Standard susy setup (useful to get core modules)
-from CMGTools.TTHAnalysis.analyzers.susyCore_modules_cff import *
+from CMGTools.TTHAnalysis.analyzers.xtracks_modules_cff import *
 
-lepAna.doMiniIsolation = "precomputed"
-lepAna.mu_isoCorr = "deltaBeta"
-lepAna.loose_muon_id     = "POG_ID_Loose"
-lepAna.loose_electron_id = "MVA_ID_nonIso_Fall17_Loose"
-lepAna.loose_muon_isoCut     = lambda muon : muon.miniRelIso < 0.4 and muon.sip3D() < 8
-lepAna.loose_electron_isoCut = lambda elec : elec.miniRelIso < 0.4 and elec.sip3D() < 8
+lepAna.loose_muon_isoCut     = lambda muon : muon.relIso03 < 0.25
+lepAna.loose_electron_isoCut = lambda elec : elec.relIso03 < 0.25
 
 tauAna.loose_ptMin = 20
 tauAna.loose_etaMax = 2.3
 tauAna.loose_tauID = "decayModeFindingNewDMs"
-tauAna.loose_vetoLeptons = False # no cleaning with leptons in production
-
-photonAna.do_mc_match = False
+tauAna.loose_vetoLeptons = False 
 
 jetAna.addJECShifts = True
 jetAna.jetPtOrUpOrDnSelection = True
 
-jetAna.copyJetsByValue = True # do not remove this
-metAna.copyMETsByValue = True # do not remove this
+jetAna.copyJetsByValue = True 
 jetAna.calculateType1METCorrection = True
-metAna.recalibrate = "type1"
 jetAnaScaleUp.calculateType1METCorrection = True
-metAnaScaleUp.recalibrate = "type1"
 jetAnaScaleDown.calculateType1METCorrection = True
-metAnaScaleDown.recalibrate = "type1"
 
-## early skimming with loose cuts (before jet-lepton cleaning, re-application of JECs, ...)
-from CMGTools.TTHAnalysis.analyzers.ttHFastMETSkimmer import ttHFastMETSkimmer
-fastMETSkim = cfg.Analyzer( ttHFastMETSkimmer, name='fastMETSkimmer',
-    met      = "slimmedMETs", # met collection to use
-    metCut    =  50,  # MET cut, looser because of non-final JECs
-    )
-from CMGTools.TTHAnalysis.analyzers.ttHFastJetSkimmer import ttHFastJetSkimmer
-fastJetSkim = cfg.Analyzer(ttHFastJetSkimmer, name="fastJetSkimmer",
-    jets = 'slimmedJets',
-    jetCut = lambda j : j.pt() > 80 and abs(j.eta()) < 2.4, # looser pt because of non-final JECs
-    minJets = 1,
-    )
+## early skimming on the isolated track
 from CMGTools.TTHAnalysis.analyzers.isoTrackFastSkimmer import isoTrackFastSkimmer
 isoTrackFastSkim = cfg.Analyzer(isoTrackFastSkimmer, name="isoTrackFastSkim",
-    cut = lambda t : (t.pt() > 50 and 
-                      abs(t.eta()) < 2.4 and 
-                      t.isHighPurityTrack() and 
+    cut = lambda t : (t.pt() > 50 and
+                      abs(t.eta()) < 2.4 and
+                      t.isHighPurityTrack() and
                       abs(t.dxy()) < 0.5 and abs(t.dz()) < 0.5 and
                       (t.miniPFIsolation().chargedHadronIso() < 1.0*t.pt() or t.pt() > 100))
 )
 
-## late skimming (after analyzers have been run)
-ttHJetMETSkim.jetPtCuts = [ 90., ]  # looser than the analysis, to allow for JEC uncertainties
-ttHJetMETSkim.metCut    =   80.
+## late skimming on jets and MET
+from CMGTools.TTHAnalysis.analyzers.xtracksFilters import xtracksFilters
+jetMETSkim = cfg.Analyzer( xtracksFilters, name='xtracksSkim',
+    jets       = "cleanJets",
+    jetPtCuts  = [ 90., ],
+    metCut     =  0,
+    metNoMuCut =  80,
+)
 
 ## Full DeDx analyzer
 from CMGTools.TTHAnalysis.analyzers.isoTrackDeDxAnalyzer import isoTrackDeDxAnalyzer
@@ -74,7 +57,7 @@ isoTrackDeDxAna = cfg.Analyzer(isoTrackDeDxAnalyzer, name="isoTrackDeDxAna",
     )
 
 ## Tree Producer
-from CMGTools.TTHAnalysis.analyzers.treeProducerSusyDeDx import *
+from CMGTools.TTHAnalysis.analyzers.treeProducerXtracks import *
 
 ## Sample production and setup
 ### Trigger
@@ -108,24 +91,20 @@ sequence = cfg.Sequence( [
     triggerAna,
 
     isoTrackFastSkim,
-    fastMETSkim,
-    fastJetSkim, 
 
     genAna,
     genHFAna,
-    #susyScanAna, # may be needed later
 
     vertexAna,
     lepAna,
     tauAna,
-    photonAna,
     jetAna,
     jetAnaScaleUp,
     jetAnaScaleDown,
     metAna,
     metAnaScaleUp,
     metAnaScaleDown,
-    ttHJetMETSkim,
+    jetMETSkim,
 
     isoTrackDeDxAna,
 
@@ -144,11 +123,9 @@ if test == "1":
 elif test == "1S":
     comp = selectedComponents[0]
     comp.name = "Signal"
-    comp.files = [ '/afs/cern.ch/work/g/gpetrucc/SusyWithDeDx/CMSSW_9_4_6_patch1/src/MiniAODv2.root' ]
+    comp.files = [ '/media/Disk1/avartak/CMS/Samples/DisappearingTracks/Wino_M_300_cTau_10/Wino_M_300_cTau_10.run17.ev17000.MiniAODv2.root' ]
     selectedComponents = doTest1(comp, sequence=sequence, cache=False )
     print "The test wil use file %s " % comp.files[0]
-    ttHJetMETSkim.jetPtCuts = [ ]  # looser than the analysis, to allow for JEC uncertainties
-    ttHJetMETSkim.metCut    =   0.
     fastJetSkim.minJets = 0
     fastMETSkim.metCut = 0
     isoTrackDeDxAna.doDeDx = True

--- a/TTHAnalysis/python/analyzers/treeProducerXtracks.py
+++ b/TTHAnalysis/python/analyzers/treeProducerXtracks.py
@@ -1,0 +1,155 @@
+#!/bin/env python
+import PhysicsTools.HeppyCore.framework.config as cfg
+from PhysicsTools.Heppy.analyzers.core.AutoFillTreeProducer import *  
+from PhysicsTools.Heppy.analyzers.core.autovars import *  
+from PhysicsTools.Heppy.analyzers.objects.autophobj import  *
+from math import *
+
+##------------------------------------------  
+## LEPTON
+##------------------------------------------  
+
+leptonTypeXtracks = NTupleObjectType("leptonXtracks", baseObjectTypes = [ leptonType ], variables = [
+    NTupleVariable("etaSc", lambda x : x.superCluster().eta() if abs(x.pdgId())==11 else -100, help="Electron supercluster pseudorapidity"),
+    NTupleVariable("mcMatchPdgId",  lambda x : x.mcLep.pdgId() if getattr(x,'mcLep',None)!=None else -99, int, mcOnly=True, help="Match to source from hard scatter (pdgId of heaviest particle in chain, 25 for H, 6 for t, 23/24 for W/Z): pdgId of the matched gen-level lepton, zero if non-prompt or fake"),
+    NTupleVariable("mcPromptGamma", lambda x : x.mcPho.isPromptFinalState() if getattr(x,"mcPho",None) else 0, int, mcOnly=True, help="Photon isPromptFinalState"),
+])
+leptonTypeXtracks.removeVariable("relIsoAn04")
+leptonTypeXtracks.removeVariable("eleCutIdSpring15_25ns_v1")
+leptonTypeXtracks.removeVariable("ICHEPsoftMuonId")
+leptonTypeXtracks.removeVariable("ICHEPmediumMuonId")
+
+##------------------------------------------  
+## TAU
+##------------------------------------------  
+
+tauTypeXtracks = NTupleObjectType("tauXtracks",  baseObjectTypes = [ tauType ], variables = [
+     NTupleVariable("idMVAdR03", lambda x : x.idMVAdR03, int, help="1,2,3,4,5,6 if the tau passes the very loose to very very tight WP of the IsolationMVArun2v1DBdR03oldDMwLT discriminator"),
+])
+tauTypeXtracks.removeVariable("idMVANewDM")
+tauTypeXtracks.removeVariable("idCI3hit")
+
+
+jetTypeXtracks = NTupleObjectType("jetXtracks",  baseObjectTypes = [ jetTypeExtra ], variables = [
+    NTupleVariable("chHEF", lambda x : x.chargedHadronEnergyFraction(), float, mcOnly = False, help="chargedHadronEnergyFraction (relative to uncorrected jet energy)"),
+    NTupleVariable("neHEF", lambda x : x.neutralHadronEnergyFraction(), float, mcOnly = False,help="neutralHadronEnergyFraction (relative to uncorrected jet energy)"),
+])
+jetTypeXtracks.removeVariable("btagCMVA")
+jetTypeXtracks.removeVariable("nLeptons")
+
+jetTypeXtracksFwd = NTupleObjectType("jetFwd",  baseObjectTypes = [ jetType ], variables = [
+    NTupleVariable("chHEF", lambda x : x.chargedHadronEnergyFraction(), float, mcOnly = False, help="chargedHadronEnergyFraction (relative to uncorrected jet energy)"),
+    NTupleVariable("neHEF", lambda x : x.neutralHadronEnergyFraction(), float, mcOnly = False,help="neutralHadronEnergyFraction (relative to uncorrected jet energy)"),
+])
+jetTypeXtracks.removeVariable("btagCMVA")
+jetTypeXtracksFwd.removeVariable("nLeptons")
+
+##------------------------------------------  
+## MET
+##------------------------------------------  
+  
+metTypeXtracks = NTupleObjectType("metXtracks", baseObjectTypes = [ metType ], variables = [
+])
+
+metTypeXtracksBasic = NTupleObjectType("metXtracksBasic", baseObjectTypes = [ fourVectorType ], variables = [
+])
+
+##------------------------------------------  
+## IsoTrackDeDx
+##------------------------------------------  
+isoTrackTypeDeDx = NTupleObjectType("isoTrackTypeDeDx", baseObjectTypes = [ particleType ], variables = [
+    NTupleVariable("charge",   lambda x : x.charge(), int),
+    NTupleVariable("dxy",   lambda x : x.dxy(), help="d_{xy} with respect to PV, in cm (with sign)"),
+    NTupleVariable("dz",    lambda x : x.dz() , help="d_{z} with respect to PV, in cm (with sign)"),
+    NTupleVariable("edxy",  lambda x : x.dxyError(), help="#sigma(d_{xy}) with respect to PV, in cm"),
+    NTupleVariable("edz", lambda x : x.dzError(), help="#sigma(d_{z}) with respect to PV, in cm"),    
+
+    NTupleVariable("trackerLayers", lambda x : x.hitPattern().trackerLayersWithMeasurement(), int, help="Tracker Layers"),
+    NTupleVariable("pixelLayers", lambda x : x.hitPattern().pixelLayersWithMeasurement(), int, help="Pixel Layers"),
+    NTupleVariable("trackerHits", lambda x : x.hitPattern().numberOfValidTrackerHits(), int, help="Tracker hits"),
+    NTupleVariable("pixelHits", lambda x : x.hitPattern().numberOfValidPixelHits(), int, help="Pixel hits"),
+    NTupleVariable("missingInnerPixelHits", lambda x : x.hitPattern().numberOfLostPixelHits(1), int, help="Missing inner pixel hits"),
+    NTupleVariable("missingOuterPixelHits", lambda x : x.hitPattern().numberOfLostPixelHits(2), int, help="Missing outer pixel hits"),
+    NTupleVariable("missingInnerStripHits", lambda x : x.hitPattern().numberOfLostStripHits(1), int, help="Missing inner strips hits"),
+    NTupleVariable("missingOuterStripHits", lambda x : x.hitPattern().numberOfLostStripHits(2), int, help="Missing outer strips hits"),
+    NTupleVariable("missingInnerTrackerHits", lambda x : x.hitPattern().numberOfLostTrackerHits(1), int, help="Missing inner tracker hits"),
+    NTupleVariable("missingOuterTrackerHits", lambda x : x.hitPattern().numberOfLostTrackerHits(2), int, help="Missing outer tracker hits"),
+    NTupleVariable("missingMiddleTrackerHits", lambda x : x.hitPattern().numberOfLostTrackerHits(0), int, help="Missing tracker hits in the middle of the track"),
+
+    NTupleVariable("highPurity", lambda x : x.isHighPurityTrack(), int, help="High purity"),
+
+    NTupleVariable("caloEmEnergy",   lambda x : x.matchedCaloJetEmEnergy(), help="Energy in the ECAL behind the track"),
+    NTupleVariable("caloHadEnergy",   lambda x : x.matchedCaloJetHadEnergy(), help="Energy in the HCAL behind the track"),
+    NTupleVariable("channelsGoodECAL", lambda x : x.channelsGoodECAL, int, help="Flag set to 1 when the track extrapolates to all good ECAL channels"),
+    NTupleVariable("channelsGoodHCAL", lambda x : x.channelsGoodHCAL, int, help="Flag set to 1 when the track extrapolates to all good HCAL channels"),
+
+    NTupleVariable("awayJet_idx", lambda x : x.leadAwayJet.index if x.leadAwayJet else -1, int),
+    NTupleVariable("awayJet_pt", lambda x : x.leadAwayJet.pt() if x.leadAwayJet else 0),
+    NTupleVariable("awayJet_dr", lambda x : deltaR(x, x.leadAwayJet) if x.leadAwayJet else 0),
+
+    NTupleVariable("awayNJet", lambda x : x.awayJetInfo['num'], int),
+    NTupleVariable("awayHTJet", lambda x : x.awayJetInfo['ht']),
+
+    NTupleVariable("awayMu_idx", lambda x : x.leadAwayMu.index if x.leadAwayMu else -1, int),
+    NTupleVariable("awayMu_dr", lambda x : deltaR(x, x.leadAwayMu) if x.leadAwayMu else 0),
+    NTupleVariable("awayMu_mll", lambda x : (x.leadAwayMu.p4()+x.p4()).M() if x.leadAwayMu else 0),
+
+    NTupleVariable("awayEle_idx", lambda x : x.leadAwayEle.index if x.leadAwayEle else -1, int),
+    NTupleVariable("awayEle_dr", lambda x : deltaR(x, x.leadAwayEle) if x.leadAwayEle else 0),
+    NTupleVariable("awayEle_mll", lambda x : (x.leadAwayEle.p4()+x.p4()).M() if x.leadAwayEle else 0),
+
+    NTupleVariable("closestMu_idx", lambda x : x.closestMu.index if x.closestMu else -1, int),
+    NTupleVariable("closestEle_idx", lambda x : x.closestEle.index if x.closestEle else -1, int),
+    NTupleVariable("closestTau_idx", lambda x : x.closestTau.index if x.closestTau else -1, int),
+
+    NTupleVariable("myDeDx", lambda x : x.myDeDx),
+
+    NTupleVariable("mcMatch", lambda x : x.mcMatch.index if x.mcMatch else -1, int, mcOnly=True),
+])
+
+##------------------------------------------  
+## genCharginoType
+##------------------------------------------  
+genCharginoType  = NTupleObjectType("genCharginoType", baseObjectTypes = [ genParticleWithMotherId ], variables = [
+    NTupleVariable("beta", lambda x : x.p()/x.energy()),
+    NTupleVariable("decayR", lambda x : x.decayPoint.R()),
+    NTupleVariable("decayZ", lambda x : x.decayPoint.Z()),
+])
+
+## Tree Producer
+treeProducer = cfg.Analyzer(
+    AutoFillTreeProducer, name='treeProducerXtracks',
+    vectorTree = True, saveTLorentzVectors = False,  defaultFloatType = 'F', PDFWeights = [],
+    globalVariables = [
+        NTupleVariable("rho",  lambda ev: ev.rho, float, help="kt6PFJets rho"),
+        NTupleVariable("nVert",  lambda ev: len(ev.goodVertices), int, help="Number of good vertices"),
+
+        NTupleVariable("nJet30", lambda ev: sum([j.pt() > 30 for j in ev.cleanJets]), int, help="Number of jets with pt > 30, |eta|<2.4"),
+        NTupleVariable("nJet30a", lambda ev: sum([j.pt() > 30 for j in ev.cleanJetsAll]), int, help="Number of jets with pt > 30, |eta|<4.7"),
+
+        ## ------- lheHT, needed for merging HT binned samples
+        NTupleVariable("lheHT", lambda ev : getattr(ev,"lheHT",-999), mcOnly=True, help="H_{T} computed from quarks and gluons in Heppy LHEAnalyzer"),
+        NTupleVariable("lheHTIncoming", lambda ev : getattr(ev,"lheHTIncoming",-999), mcOnly=True, help="H_{T} computed from quarks and gluons in Heppy LHEAnalyzer (only LHE status<0 as mothers)"),
+        ],
+    globalObjects = {
+        "met"             : NTupleObject("met", metTypeXtracks, help="PF E_{T}^{miss}"),
+        "metNoMu"         : NTupleObject("metNoMu", metTypeXtracksBasic, help="PF E_{T}^{miss} without muons"),
+        "met_jecUp"       : NTupleObject("met_jecUp", metTypeXtracks, help="PF E_{T}^{miss}, after type 1 corrections (JEC plus 1sigma)"),
+        "metNoMu_jecUp"   : NTupleObject("metNoMu_jecUp", metTypeXtracksBasic, help="PF E_{T}^{miss} without muons, after type 1 corrections (JEC plus 1sigma)"),
+        "met_jecDown"     : NTupleObject("met_jecDown", metTypeXtracks, help="PF E_{T}^{miss}, after type 1 corrections (JEC minus 1sigma)"),
+        "metNoMu_jecDown" : NTupleObject("metNoMu_jecUp", metTypeXtracksBasic, help="PF E_{T}^{miss} without muons, after type 1 corrections (JEC minus 1sigma)"),
+        },
+    collections = {
+        ##--------------------------------------------------
+        "selectedTaus"    : NTupleCollection("TauGood",  tauTypeXtracks, 8, help="Taus after the preselection"),
+        "selectedLeptons" : NTupleCollection("LepGood",  leptonTypeXtracks, 8, help="Leptons after the preselection"),
+        ##------------------------------------------------
+        "cleanJets"       : NTupleCollection("Jet",     jetTypeXtracks, 15, help="Cental jets after full selection and cleaning, sorted by pt"),
+        "cleanJetsFwd"    : NTupleCollection("JetFwd",  jetTypeXtracksFwd,  6, help="Forward jets after full selection and cleaning, sorted by pt"),
+        ##------------------------------------------------
+        "isoTracks"       : NTupleCollection("IsoTrack",  isoTrackTypeDeDx, 4, help="Isolated tracks"),
+        ##------------------------------------------------
+        "genCharginos"    : NTupleCollection("GenChargino",  genCharginoType, 4, mcOnly=True, help="Gen chargino"),
+        },
+    )
+

--- a/TTHAnalysis/python/analyzers/xtracksFilters.py
+++ b/TTHAnalysis/python/analyzers/xtracksFilters.py
@@ -1,0 +1,43 @@
+from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
+from PhysicsTools.HeppyCore.framework.event import Event
+from PhysicsTools.HeppyCore.statistics.counter import Counter, Counters
+from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
+
+class xtracksFilters( Analyzer ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(xtracksFilters,self).__init__(cfg_ana,cfg_comp,looperName)
+
+    def declareHandles(self):
+        super(xtracksFilters, self).declareHandles()
+
+    def beginLoop(self,setup):
+        super(xtracksFilters,self).beginLoop(setup)
+        self.counters.addCounter('events')
+        count = self.counters.counter('events')
+        count.register('all events')
+        count.register('pass jetPtCuts')
+        count.register('pass met')
+        count.register('pass metNoMu')
+        count.register('accepted events')
+
+
+    def process(self, event):
+        self.readCollections( event.input )
+        self.counters.counter('events').inc('all events')
+
+        jets = getattr(event, self.cfg_ana.jets)
+        for i,ptCut in enumerate(self.cfg_ana.jetPtCuts):
+            if len(jets) <= i or jets[i].pt() <= ptCut:
+                return False
+        self.counters.counter('events').inc('pass jetPtCuts')
+        
+        if float(self.cfg_ana.metCut) > 0 and event.met.pt() <= self.cfg_ana.metCut:
+            return False
+        self.counters.counter('events').inc('pass met')
+
+        if float(self.cfg_ana.metNoMuCut) > 0 and event.metNoMu.pt() <= self.cfg_ana.metNoMuCut:
+            return False
+        self.counters.counter('events').inc('pass metNoMu')
+
+        self.counters.counter('events').inc('accepted events')
+        return True

--- a/TTHAnalysis/python/analyzers/xtracks_modules_cff.py
+++ b/TTHAnalysis/python/analyzers/xtracks_modules_cff.py
@@ -1,0 +1,342 @@
+##########################################################
+##          SUSY COMMON MODULES ARE DEFINED HERE        ##
+## skimming modules are configured to not cut anything  ##
+##########################################################
+
+import PhysicsTools.HeppyCore.framework.config as cfg
+from PhysicsTools.Heppy.analyzers.core.all import *
+from PhysicsTools.Heppy.analyzers.objects.all import *
+from PhysicsTools.Heppy.analyzers.gen.all import *
+import os
+
+PDFWeights = []
+#PDFWeights = [ ("CT10",53), ("MSTW2008lo68cl",41), ("NNPDF21_100",101) ]
+
+# Find the initial events before the skim
+skimAnalyzer = cfg.Analyzer(
+    SkimAnalyzerCount, name='skimAnalyzerCount',
+    useLumiBlocks = False,
+    )
+
+# Pick individual events (normally not in the path)
+eventSelector = cfg.Analyzer(
+    EventSelector,name="EventSelector",
+    toSelect = []  # here put the event numbers (actual event numbers from CMSSW)
+    )
+
+# Apply json file (if the dataset has one)
+jsonAna = cfg.Analyzer(
+    JSONAnalyzer, name="JSONAnalyzer",
+    )
+
+# Filter using the 'triggers' and 'vetoTriggers' specified in the dataset
+triggerAna = cfg.Analyzer(
+    TriggerBitFilter, name="TriggerBitFilter",
+    )
+
+# Create flags for trigger bits
+triggerFlagsAna = cfg.Analyzer(
+    TriggerBitAnalyzer, name="TriggerFlags",
+    processName = 'HLT',
+    fallbackProcessName = 'HLT2',
+    prescaleProcessName = 'PAT',
+    prescaleFallbackProcessName = 'RECO',
+    unrollbits = False,
+    saveIsUnprescaled = False,
+    checkL1prescale = False,
+    triggerBits = {
+        # "<name>" : [ 'HLT_<Something>_v*', 'HLT_<SomethingElse>_v*' ] 
+    }
+    )
+# Create flags for MET filter bits
+eventFlagsAna = cfg.Analyzer(
+    TriggerBitAnalyzer, name="EventFlags",
+    processName = 'PAT',
+    fallbackProcessName = 'RECO', 
+    outprefix   = 'Flag',
+    triggerBits = {
+        "HBHENoiseFilter" : [ "Flag_HBHENoiseFilter" ],
+        "HBHENoiseIsoFilter" : [ "Flag_HBHENoiseIsoFilter" ],
+        "globalTightHalo2016Filter" : [ "Flag_globalTightHalo2016Filter" ],
+        "EcalDeadCellTriggerPrimitiveFilter" : [ "Flag_EcalDeadCellTriggerPrimitiveFilter" ],
+        "goodVertices" : [ "Flag_goodVertices" ],
+        "eeBadScFilter" : [ "Flag_eeBadScFilter" ],
+        "ecalBadCalibFilter" : [ "Flag_ecalBadCalibFilter" ],
+        "BadPFMuonFilter" : [ "Flag_BadPFMuonFilter" ],
+        "BadChargedCandidateFilter" : [ "BadChargedCandidateFilter" ],
+        }
+    )
+
+from CMGTools.TTHAnalysis.analyzers.badChargedHadronAnalyzer import badChargedHadronAnalyzer
+badChargedHadronAna = cfg.Analyzer(
+    badChargedHadronAnalyzer, name = 'badChargedHadronAna',
+    muons='slimmedMuons',
+    packedCandidates = 'packedPFCandidates',
+)
+
+from CMGTools.TTHAnalysis.analyzers.badMuonAnalyzer import badMuonAnalyzer
+badMuonAna = cfg.Analyzer(
+    badMuonAnalyzer, name = 'badMuonAna',
+    muons='slimmedMuons',
+    packedCandidates = 'packedPFCandidates',
+)
+
+from CMGTools.TTHAnalysis.analyzers.badMuonAnalyzerMoriond2017 import badMuonAnalyzerMoriond2017
+badCloneMuonAnaMoriond2017 = cfg.Analyzer(
+    badMuonAnalyzerMoriond2017, name = 'badCloneMuonMoriond2017',
+    muons = 'slimmedMuons',
+    vertices         = 'offlineSlimmedPrimaryVertices',
+    minMuPt = 20,
+    selectClones = True,
+    postFix = '',
+)
+
+badMuonAnaMoriond2017 = cfg.Analyzer(
+    badMuonAnalyzerMoriond2017, name = 'badMuonMoriond2017',
+    muons = 'slimmedMuons',
+    vertices         = 'offlineSlimmedPrimaryVertices',
+    minMuPt = 20,
+    selectClones = False,
+    postFix = '',
+)
+
+
+# Select a list of good primary vertices (generic)
+vertexAna = cfg.Analyzer(
+    VertexAnalyzer, name="VertexAnalyzer",
+    vertexWeight = None,
+    fixedWeight = 1,
+    verbose = False
+    )
+
+
+# This analyzer actually does the pile-up reweighting (generic)
+pileUpAna = cfg.Analyzer(
+    PileUpAnalyzer, name="PileUpAnalyzer",
+    true = True,  # use number of true interactions for reweighting
+    makeHists=True
+    )
+
+
+## Gen Info Analyzer (generic, but should be revised)
+genAna = cfg.Analyzer(
+    GeneratorAnalyzer, name="GeneratorAnalyzer",
+    # BSM particles that can appear with status <= 2 and should be kept
+    stableBSMParticleIds = [ 1000022 ],
+    # Particles of which we want to save the pre-FSR momentum (a la status 3).
+    # Note that for quarks and gluons the post-FSR doesn't make sense,
+    # so those should always be in the list
+    savePreFSRParticleIds = [ 1,2,3,4,5, 11,12,13,14,15,16, 21,22 ],
+    # Make also the list of all genParticles, for other analyzers to handle
+    makeAllGenParticles = True,
+    # Make also the splitted lists
+    makeSplittedGenLists = True,
+    allGenTaus = False,
+    # Print out debug information
+    verbose = False,
+    )
+
+genHFAna = cfg.Analyzer(
+    GenHeavyFlavourAnalyzer, name="GenHeavyFlavourAnalyzer",
+    status2Only = False,
+    bquarkPtCut = 15.0,
+)
+
+lheWeightAna = cfg.Analyzer(
+    LHEWeightAnalyzer, name="LHEWeightAnalyzer",
+    useLumiInfo=False
+)
+
+pdfwAna = cfg.Analyzer(
+    PDFWeightsAnalyzer, name="PDFWeightsAnalyzer",
+    PDFWeights = [ pdf for pdf,num in PDFWeights ]
+    )
+
+# Lepton Analyzer (generic)
+lepAna = cfg.Analyzer(
+    LeptonAnalyzer, name="leptonAnalyzer",
+    # input collections
+    muons='slimmedMuons',
+    electrons='slimmedElectrons',
+    rhoMuon= 'fixedGridRhoFastjetAll',
+    rhoElectron = 'fixedGridRhoFastjetAll',
+    # energy scale corrections and ghost muon suppression (off by default)
+    doMuonScaleCorrections=False,
+    doElectronScaleCorrections=False, # "embedded" in 5.18 for regression
+    doSegmentBasedMuonCleaning=False,
+    # inclusive very loose muon selection
+    inclusive_muon_id  = "POG_ID_Loose",
+    inclusive_muon_pt  = 3,
+    inclusive_muon_eta = 2.4,
+    inclusive_muon_dxy = 0.5,
+    inclusive_muon_dz  = 1.0,
+    muon_dxydz_track = "innerTrack",
+    # loose muon selection
+    loose_muon_id     = "POG_ID_Loose",
+    loose_muon_pt     = 10,
+    loose_muon_eta    = 2.4,
+    loose_muon_dxy    = 0.05,
+    loose_muon_dz     = 0.1,
+    loose_muon_relIso = 1e9,
+    # inclusive very loose electron selection
+    inclusive_electron_id  = "",
+    inclusive_electron_pt  = 5,
+    inclusive_electron_eta = 2.5,
+    inclusive_electron_dxy = 0.5,
+    inclusive_electron_dz  = 1.0,
+    inclusive_electron_lostHits = 1.0,
+    # loose electron selection
+    loose_electron_id     = "POG_Cuts_ID_FALL17_94X_v1_ConvVetoDxyDz_Veto",
+    loose_electron_pt     = 10,
+    loose_electron_eta    = 2.5,
+    loose_electron_dxy    = 0.5,
+    loose_electron_dz     = 1.0,
+    loose_electron_relIso = 1e9,
+    loose_electron_lostHits = 10.0,
+    # muon isolation correction method (can be "rhoArea" or "deltaBeta")
+    mu_isoCorr = "deltaBeta" ,
+    mu_effectiveAreas = "Fall17", #(can be 'Data2012' or 'Phys14_25ns_v1' or 'Spring15_25ns_v1')
+    # electron isolation correction method (can be "rhoArea" or "deltaBeta")
+    ele_isoCorr = "rhoArea" ,
+    ele_effectiveAreas = "Fall17" , #(can be 'Data2012' or 'Phys14_25ns_v1' or 'Spring15_25ns_v1')
+    ele_tightId = "Cuts_FALL17_94X_v1_ConvVetoDxyDz" ,
+    # Mini-isolation, with pT dependent cone: will fill in the miniRelIso, miniRelIsoCharged, miniRelIsoNeutral variables of the leptons (see https://indico.cern.ch/event/368826/ )
+    doMiniIsolation = False, # off by default since it requires access to all PFCandidates 
+    packedCandidates = 'packedPFCandidates',
+    miniIsolationPUCorr = 'rhoArea', # Allowed options: 'rhoArea' (EAs for 03 cone scaled by R^2), 'deltaBeta', 'raw' (uncorrected), 'weights' (delta beta weights; not validated)
+    miniIsolationVetoLeptons = None, # use 'inclusive' to veto inclusive leptons and their footprint in all isolation cones
+    doDirectionalIsolation = [], # calculate directional isolation with leptons (works only with doMiniIsolation, pass list of cone sizes)
+    doFixedConeIsoWithMiniIsoVeto = False, # calculate fixed cone isolations with the same vetoes used for miniIso,
+    # minimum deltaR between a loose electron and a loose muon (on overlaps, discard the electron)
+    min_dr_electron_muon = 0.05,
+    # do MC matching 
+    do_mc_match = True, # note: it will in any case try it only on MC, not on data
+    do_mc_match_photons = "all",
+    match_inclusiveLeptons = False, # match to all inclusive leptons
+    )
+
+## Tau Analyzer (generic)
+tauAna = cfg.Analyzer(
+    TauAnalyzer, name="tauAnalyzer",
+    # inclusive very loose hadronic tau selection
+    inclusive_ptMin = 18,
+    inclusive_etaMax = 9999,
+    inclusive_dxyMax = 1000.,
+    inclusive_dzMax = 0.4,
+    inclusive_vetoLeptons = False,
+    inclusive_leptonVetoDR = 0.4,
+    inclusive_decayModeID = "decayModeFindingNewDMs", # ignored if not set or ""
+    inclusive_tauID = "decayModeFindingNewDMs",
+    inclusive_vetoLeptonsPOG = False, # If True, the following two IDs are required
+    inclusive_tauAntiMuonID = "",
+    inclusive_tauAntiElectronID = "",
+    # loose hadronic tau selection
+    loose_ptMin = 18,
+    loose_etaMax = 9999,
+    loose_dxyMax = 1000.,
+    loose_dzMax = 0.2,
+    loose_vetoLeptons = True,
+    loose_leptonVetoDR = 0.4,
+    loose_decayModeID = "decayModeFindingNewDMs", # ignored if not set or ""
+    loose_tauID = "byLooseCombinedIsolationDeltaBetaCorr3Hits",
+    loose_vetoLeptonsPOG = False, # If True, the following two IDs are required
+    loose_tauAntiMuonID = "againstMuonLoose3",
+    loose_tauAntiElectronID = "againstElectronLooseMVA5",
+
+)
+
+## Jets Analyzer (generic)
+jetAna = cfg.Analyzer(
+    JetAnalyzer, name='jetAnalyzer',
+    jetCol = 'slimmedJets',
+    copyJetsByValue = False,      #Whether or not to copy the input jets or to work with references (should be 'True' if JetAnalyzer is run more than once)
+    genJetCol = 'slimmedGenJets',
+    rho = ('fixedGridRhoFastjetAll','',''),
+    jetPt = 25.,
+    jetEta = 4.7,
+    jetEtaCentral = 2.4,
+    cleanJetsFromLeptons = True,
+    jetLepDR = 0.4,
+    jetLepArbitration = (lambda jet,lepton : lepton), # you can decide which to keep in case of overlaps; e.g. if the jet is b-tagged you might want to keep the jet
+    cleanSelectedLeptons = True, #Whether to clean 'selectedLeptons' after disambiguation. Treat with care (= 'False') if running Jetanalyzer more than once
+    minLepPt = 10,
+    lepSelCut = lambda lep : True,
+    relaxJetId = False,  
+    doPuId = False, # Not commissioned in 7.0.X
+    recalibrateJets = True, #'MC', # True, False, 'MC', 'Data'
+    applyL2L3Residual = True, # Switch to 'Data' when they will become available for Data
+    recalibrationType = "AK4PFchs",
+    mcGT     = "Fall17_17Nov2017_V6_MC",
+    dataGT   = [(1,"Fall17_17Nov2017B_V6_DATA"),(299337,"Fall17_17Nov2017C_V6_DATA"),(302030,"Fall17_17Nov2017D_V6_DATA"),(303435,"Fall17_17Nov2017E_V6_DATA"),(304911,"Fall17_17Nov2017F_V6_DATA")],
+    jecPath = "${CMSSW_BASE}/src/CMGTools/RootTools/data/jec/",
+    shiftJEC = 0, # set to +1 or -1 to apply +/-1 sigma shift to the nominal jet energies
+    addJECShifts = False, # if true, add  "corr", "corrJECUp", and "corrJECDown" for each jet (requires uncertainties to be available!)
+    jetPtOrUpOrDnSelection = False, # if true, apply pt cut on the maximum among central, JECUp and JECDown values of corrected pt
+    smearJets = False,
+    shiftJER = 0, # set to +1 or -1 to get +/-1 sigma shifts  
+    alwaysCleanPhotons = False,
+    cleanGenJetsFromPhoton = False,
+    cleanJetsFromFirstPhoton = False,
+    cleanJetsFromTaus = False,
+    cleanJetsFromIsoTracks = False,
+    doQG = False,
+    do_mc_match = True,
+    collectionPostFix = "",
+    calculateSeparateCorrections = True, # should be True if recalibrateJets is True, otherwise L1s will be inconsistent
+    calculateType1METCorrection  = False,
+    type1METParams = { 'jetPtThreshold':15., 'skipEMfractionThreshold':0.9, 'skipMuons':True },
+    storeLowPtJets = False,
+    )
+
+## Jets Analyzer (generic)
+jetAnaScaleUp = jetAna.clone(name='jetAnalyzerScaleUp',
+    copyJetsByValue = True,
+    jetCol = 'slimmedJets',
+    shiftJEC = +1, # set to +1 or -1 to apply +/-1 sigma shift to the nominal jet energies
+    collectionPostFix = "_jecUp",
+    calculateType1METCorrection  = True,
+    cleanSelectedLeptons = False,
+   )
+
+## Jets Analyzer (generic)
+jetAnaScaleDown = jetAna.clone(name='jetAnalyzerScaleDown',
+    copyJetsByValue = True,
+    jetCol = 'slimmedJets',
+    shiftJEC = -1, # set to +1 or -1 to apply +/-1 sigma shift to the nominal jet energies
+    collectionPostFix = "_jecDown",
+    calculateType1METCorrection  = True,
+    cleanSelectedLeptons = False,
+    )
+
+metAna = cfg.Analyzer(
+    METAnalyzer, name="metAnalyzer",
+    metCollection     = "slimmedMETs",
+    noPUMetCollection = "slimmedMETs",    
+    copyMETsByValue = True,
+    doTkMet = False,
+    doPuppiMet = False,
+    doMetNoPU = False,
+    doMetNoMu = True,
+    doMetNoEle = False,
+    doMetNoPhoton = False,
+    storePuppiExtra = False, # False for MC, True for re-MiniAOD
+    recalibrate = "type1", # or False or True
+    applyJetSmearing = False, # does nothing unless the jet smearing is turned on in the jet analyzer
+    old74XMiniAODs = False, # set to True to get the correct Raw MET when running on old 74X MiniAODs
+    jetAnalyzerPostFix = "",
+    candidates='packedPFCandidates',
+    candidatesTypes='std::vector<pat::PackedCandidate>',
+    dzMax = 0.1,
+    collectionPostFix = "",
+    )
+
+metAnaScaleUp = metAna.clone(name="metAnalyzerScaleUp",
+    jetAnalyzerPostFix = "_jecUp",
+    collectionPostFix = "_jecUp",
+    )
+
+metAnaScaleDown = metAna.clone(name="metAnalyzerScaleDown",
+    jetAnalyzerPostFix = "_jecDown",
+    collectionPostFix = "_jecDown",
+    )
+


### PR DESCRIPTION
Added METNoMu 4-vectors to the tree
Skimming is now done on METNoMu instead of MET
Moved the module and ntuple definitions to separate files to decouple their definitions from the SUSY modules (to avoid conflict in case we want to define things differently)

There are other changes to PhysicsTools/Heppy to go with these changes that will need a separate PR 