### PR TITLE
Implement 1L control region, add signal MC

### DIFF
--- a/TTHAnalysis/cfg/run_susyDeDx_cfg.py
+++ b/TTHAnalysis/cfg/run_susyDeDx_cfg.py
@@ -29,19 +29,28 @@ triggerFlagsAna.triggerBits = {
 ### MC
 from CMGTools.RootTools.samples.samples_13TeV_RunIIFall17MiniAOD import *
 Top = [ TTLep_pow, TTSemi_pow, T_tch, TBar_tch, T_tWch_noFullyHad, TBar_tWch_noFullyHad ]
+
+Wino_M_300_cTau_3  = kreator.makeMCComponentFromEOS("Wino_M_300_cTau_3",  "Wino_M_300_cTau_3",  "/store/cmst3/user/gpetrucc/SusyWithDeDx/%s.merged", ".*root", 1)
+Wino_M_300_cTau_10 = kreator.makeMCComponentFromEOS("Wino_M_300_cTau_10", "Wino_M_300_cTau_10", "/store/cmst3/user/gpetrucc/SusyWithDeDx/%s.merged", ".*root", 1)
+Wino_M_300_cTau_30 = kreator.makeMCComponentFromEOS("Wino_M_300_cTau_30", "Wino_M_300_cTau_30", "/store/cmst3/user/gpetrucc/SusyWithDeDx/%s.merged", ".*root", 1)
+Wino_M_500_cTau_10 = kreator.makeMCComponentFromEOS("Wino_M_500_cTau_10", "Wino_M_500_cTau_10", "/store/cmst3/user/gpetrucc/SusyWithDeDx/%s.merged", ".*root", 1)
+Winos = [ Wino_M_300_cTau_3  , Wino_M_300_cTau_10 , Wino_M_300_cTau_30 , Wino_M_500_cTau_10 ]
+
 if region == "sr":   
     mcSamples = ([ W3JetsToLNu_LO, W1JetsToLNu_LO, W2JetsToLNu_LO, W4JetsToLNu_LO ]
                  + DYJetsToLLM50HT + DYJetsToLLM4to50HT
                  + ZvvLOHT 
                  + Top )
+    mcSignals = Winos
     mcTriggers = triggers_SOS_highMET[:] 
 elif region == "cr1l": 
     mcSamples = [ DYJetsToLL_M50, WJetsToLNu_LO ] + Top
     mcTriggers = triggers_1mu_iso + triggers_1e_iso + triggers_1e_noniso
+    mcSignals = []
 
 autoAAA(mcSamples)
 cropToLumi(mcSamples, 10*41.7)
-for c in mcSamples:
+for c in mcSamples + mcSignals:
     c.triggers = mcTriggers
 
 ## Data
@@ -63,9 +72,10 @@ for (pdname, trigs) in datasetsAndTriggers:
     vetoTriggers += trigs
 
 run = getHeppyOption("run","all")
-if run == "all":    selectedComponents = mcSamples + dataSamples
+if run == "all":    selectedComponents = mcSamples + dataSamples + mcSignals
 elif run == "data": selectedComponents = dataSamples
 elif run == "mc":   selectedComponents = mcSamples
+elif run == "sig":  selectedComponents = mcSignals
 
 
 #-------- SEQUENCE -----------
@@ -84,7 +94,6 @@ elif test == "1S":
     selectedComponents = doTest1(comp, sequence=sequence, cache=False )
     print "The test wil use file %s " % comp.files[0]
     fastJetSkim.minJets = 0
-    fastMETSkim.metCut = 0
     isoTrackDeDxAna.doDeDx = True
     comp.triggers = []
 elif test in ('2','3','5s'):

--- a/TTHAnalysis/cfg/run_susyDeDx_cfg.py
+++ b/TTHAnalysis/cfg/run_susyDeDx_cfg.py
@@ -2,7 +2,7 @@
 ##       CONFIGURATION FOR SUSY STOP SOFT B TREES       ##
 ##########################################################
 import PhysicsTools.HeppyCore.framework.config as cfg
-import re
+import re, sys
 
 #-------- LOAD ALL ANALYZERS -----------
 from PhysicsTools.HeppyCore.framework.heppy_loop import getHeppyOption
@@ -11,59 +11,11 @@ from CMGTools.RootTools.samples.autoAAAconfig import *
 
 from CMGTools.TTHAnalysis.analyzers.xtracks_modules_cff import *
 
-lepAna.loose_muon_isoCut     = lambda muon : muon.relIso03 < 0.25
-lepAna.loose_electron_isoCut = lambda elec : elec.relIso03 < 0.25
+## Configuration that depends on the region
+region = getHeppyOption("region","sr") # use 'sr' or "cr1l"
 
-tauAna.loose_ptMin = 20
-tauAna.loose_etaMax = 2.3
-tauAna.loose_tauID = "decayModeFindingNewDMs"
-tauAna.loose_vetoLeptons = False 
-
-jetAna.addJECShifts = True
-jetAna.jetPtOrUpOrDnSelection = True
-
-jetAna.copyJetsByValue = True 
-jetAna.calculateType1METCorrection = True
-jetAnaScaleUp.calculateType1METCorrection = True
-jetAnaScaleDown.calculateType1METCorrection = True
-
-## early skimming on the isolated track
-from CMGTools.TTHAnalysis.analyzers.ttHFastJetSkimmer import ttHFastJetSkimmer
-fastJetSkim = cfg.Analyzer(ttHFastJetSkimmer, name="fastJetSkimmer",
-    jets = 'slimmedJets',
-    jetCut = lambda j : j.pt() > 80 and abs(j.eta()) < 2.4, # looser pt because of non-final JECs
-    minJets = 1,
-    )
-from CMGTools.TTHAnalysis.analyzers.isoTrackFastSkimmer import isoTrackFastSkimmer
-isoTrackFastSkim = cfg.Analyzer(isoTrackFastSkimmer, name="isoTrackFastSkim",
-    cut = lambda t : (t.pt() > 50 and
-                      abs(t.eta()) < 2.4 and
-                      t.isHighPurityTrack() and
-                      abs(t.dxy()) < 0.5 and abs(t.dz()) < 0.5 and
-                      (t.miniPFIsolation().chargedHadronIso() < 1.0*t.pt() or t.pt() > 100))
-)
-
-## late skimming on jets and MET
-from CMGTools.TTHAnalysis.analyzers.xtracksFilters import xtracksFilters
-jetMETSkim = cfg.Analyzer( xtracksFilters, name='xtracksSkim',
-    jets       = "cleanJets",
-    jetPtCuts  = [ 90., ],
-    metCut     =  0,
-    metNoMuCut =  80,
-)
-
-## Full DeDx analyzer
-from CMGTools.TTHAnalysis.analyzers.isoTrackDeDxAnalyzer import isoTrackDeDxAnalyzer
-isoTrackDeDxAna = cfg.Analyzer(isoTrackDeDxAnalyzer, name="isoTrackDeDxAna",
-    doDeDx = "94XMiniAODv1-Hack", 
-        # for 94X MiniAOD v2, just set it to True
-        # for 94X MiniAOD v1, you have two options
-        #  - set it to False, and have no DeDx
-        #  - set it to "94XMiniAODv1-Hack" and follow step (1) of https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3586/1/1/1/1.html 
-    )
-
-## Tree Producer
-from CMGTools.TTHAnalysis.analyzers.treeProducerXtracks import *
+fastJetSkim.minJets = 1 if region =="sr" else 0
+eventSkim.region = region
 
 ## Sample production and setup
 ### Trigger
@@ -73,53 +25,51 @@ triggerFlagsAna.triggerBits = {
     'SingleEl' : triggers_1e_iso + triggers_1e_noniso,
     'MET'      : triggers_SOS_highMET
 }
-triggerFlagsAna.unrollbits = True
 
 ### MC
 from CMGTools.RootTools.samples.samples_13TeV_RunIIFall17MiniAOD import *
-mcSamples = [ W3JetsToLNu_LO ]
+Top = [ TTLep_pow, TTSemi_pow, T_tch, TBar_tch, T_tWch_noFullyHad, TBar_tWch_noFullyHad ]
+if region == "sr":   
+    mcSamples = ([ W3JetsToLNu_LO, W1JetsToLNu_LO, W2JetsToLNu_LO, W4JetsToLNu_LO ]
+                 + DYJetsToLLM50HT + DYJetsToLLM4to50HT
+                 + ZvvLOHT 
+                 + Top )
+    mcTriggers = triggers_SOS_highMET[:] 
+elif region == "cr1l": 
+    mcSamples = [ DYJetsToLL_M50, WJetsToLNu_LO ] + Top
+    mcTriggers = triggers_1mu_iso + triggers_1e_iso + triggers_1e_noniso
+
 autoAAA(mcSamples)
+cropToLumi(mcSamples, 10*41.7)
 for c in mcSamples:
-    c.triggers = triggers_1mu_iso[:]
-    c.triggers += triggers_1e_iso + triggers_1e_noniso
-    c.triggers += triggers_SOS_highMET
+    c.triggers = mcTriggers
 
 ## Data
 from CMGTools.RootTools.samples.samples_13TeV_DATA2017 import *
-selectedComponents = mcSamples # + dataSamples
+if region == "sr":   
+    datasetsAndTriggers = [ ("MET", triggers_SOS_highMET) ]
+elif region == "cr1l":   
+    datasetsAndTriggers = [ ("SingleMuon", triggers_1mu_iso),
+                            ("SingleElectron", triggers_1e_iso + triggers_1e_noniso) ]
+json = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/ReReco/Cert_294927-306462_13TeV_EOY2017ReReco_Collisions17_JSON.txt'
+dataSamples = []; vetoTriggers = []
+for (pdname, trigs) in datasetsAndTriggers:
+    for d in dataSamples_17Nov2017:
+        if pdname in d.name:
+            d.json = json
+            d.triggers = trigs[:]
+            d.vetoTriggers = vetoTriggers[:]
+            dataSamples.append(d)
+    vetoTriggers += trigs
+
+run = getHeppyOption("run","all")
+if run == "all":    selectedComponents = mcSamples + dataSamples
+elif run == "data": selectedComponents = dataSamples
+elif run == "mc":   selectedComponents = mcSamples
+
 
 #-------- SEQUENCE -----------
-sequence = cfg.Sequence( [
-    lheWeightAna,
-    pileUpAna,
-    skimAnalyzer,
-    jsonAna,
-    triggerAna,
-
-    fastJetSkim,
-    isoTrackFastSkim,
-
-    genAna,
-    genHFAna,
-
-    vertexAna,
-    lepAna,
-    tauAna,
-    jetAna,
-    jetAnaScaleUp,
-    jetAnaScaleDown,
-    metAna,
-    metAnaScaleUp,
-    metAnaScaleDown,
-    jetMETSkim,
-
-    isoTrackDeDxAna,
-
-    triggerFlagsAna,
-    eventFlagsAna,
-
-    treeProducer,
-])
+sequence = cfg.Sequence( xtracks_sequence )
 
 #-------- HOW TO RUN -----------
 test = getHeppyOption('test')
@@ -130,7 +80,7 @@ if test == "1":
 elif test == "1S":
     comp = selectedComponents[0]
     comp.name = "Signal"
-    comp.files = [ '/media/Disk1/avartak/CMS/Samples/DisappearingTracks/Wino_M_300_cTau_10/Wino_M_300_cTau_10.run17.ev17000.MiniAODv2.root' ]
+    comp.files = [ '/eos/cms/store/cmst3/user/gpetrucc/SusyWithDeDx/Wino_M_500_cTau_10.merged/Wino_M_500_cTau_10.MiniAODv2_job1.root' ]
     selectedComponents = doTest1(comp, sequence=sequence, cache=False )
     print "The test wil use file %s " % comp.files[0]
     fastJetSkim.minJets = 0
@@ -141,5 +91,5 @@ elif test in ('2','3','5s'):
     doTestN(test,selectedComponents)
 
 printSummary(selectedComponents)
-
-config = autoConfig(selectedComponents, sequence) #, xrd_aggressive=-1)
+if getHeppyOption("justSummary",False): sys.exit(0)
+config = autoConfig(selectedComponents, sequence)

--- a/TTHAnalysis/python/analyzers/treeProducerXtracks.py
+++ b/TTHAnalysis/python/analyzers/treeProducerXtracks.py
@@ -102,6 +102,8 @@ isoTrackTypeDeDx = NTupleObjectType("isoTrackTypeDeDx", baseObjectTypes = [ part
     NTupleVariable("closestEle_idx", lambda x : x.closestEle.index if x.closestEle else -1, int),
     NTupleVariable("closestTau_idx", lambda x : x.closestTau.index if x.closestTau else -1, int),
 
+    NTupleVariable("trigLepton_idx", lambda x : x.trigLepton.index if getattr(x, 'trigLepton', None) else -1, int),
+
     NTupleVariable("myDeDx", lambda x : x.myDeDx),
 
     NTupleVariable("mcMatch", lambda x : x.mcMatch.index if x.mcMatch else -1, int, mcOnly=True),

--- a/TTHAnalysis/python/analyzers/xtracksFilters.py
+++ b/TTHAnalysis/python/analyzers/xtracksFilters.py
@@ -1,6 +1,7 @@
 from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
 from PhysicsTools.HeppyCore.framework.event import Event
 from PhysicsTools.HeppyCore.statistics.counter import Counter, Counters
+from PhysicsTools.HeppyCore.utils.deltar import deltaR2
 from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
 
 class xtracksFilters( Analyzer ):
@@ -15,9 +16,14 @@ class xtracksFilters( Analyzer ):
         self.counters.addCounter('events')
         count = self.counters.counter('events')
         count.register('all events')
-        count.register('pass jetPtCuts')
-        count.register('pass met')
-        count.register('pass metNoMu')
+        if self.cfg_ana.region == "sr":
+            count.register('pass jetPtCuts')
+            count.register('pass met')
+            count.register('pass metNoMu')
+        elif self.cfg_ana.region == "cr1l":
+            count.register('pass lep')
+            count.register('pass lepTrigMatch')
+            count.register('pass lepTrackPair')
         count.register('accepted events')
 
 
@@ -25,19 +31,39 @@ class xtracksFilters( Analyzer ):
         self.readCollections( event.input )
         self.counters.counter('events').inc('all events')
 
-        jets = getattr(event, self.cfg_ana.jets)
-        for i,ptCut in enumerate(self.cfg_ana.jetPtCuts):
-            if len(jets) <= i or jets[i].pt() <= ptCut:
+        if self.cfg_ana.region == "sr":
+            jets = getattr(event, self.cfg_ana.jets)
+            for i,ptCut in enumerate(self.cfg_ana.jetPtCuts):
+                if len(jets) <= i or jets[i].pt() <= ptCut:
+                    return False
+            self.counters.counter('events').inc('pass jetPtCuts')
+            
+            if float(self.cfg_ana.metCut) > 0 and event.met.pt() <= self.cfg_ana.metCut:
                 return False
-        self.counters.counter('events').inc('pass jetPtCuts')
-        
-        if float(self.cfg_ana.metCut) > 0 and event.met.pt() <= self.cfg_ana.metCut:
-            return False
-        self.counters.counter('events').inc('pass met')
+            self.counters.counter('events').inc('pass met')
 
-        if float(self.cfg_ana.metNoMuCut) > 0 and event.metNoMu.pt() <= self.cfg_ana.metNoMuCut:
-            return False
-        self.counters.counter('events').inc('pass metNoMu')
+            if float(self.cfg_ana.metNoMuCut) > 0 and event.metNoMu.pt() <= self.cfg_ana.metNoMuCut:
+                return False
+            self.counters.counter('events').inc('pass metNoMu')
+
+        elif self.cfg_ana.region == "cr1l":
+            if len(event.selectedLeptons) == 0: return False
+            self.counters.counter('events').inc('pass lep')
+
+            trigMatchLep = [ l for l in event.selectedLeptons if l.pt() > 27 and l.matchedTrgObjSingleLep ]
+            if len(trigMatchLep) == 0: return False
+            self.counters.counter('events').inc('pass lepTrigMatch')
+
+            passPair = False
+            for t in event.isoTracks:
+                t.trigLepton = None
+                for l in trigMatchLep:
+                    if deltaR2(t,l) > 1.0:
+                        passPair = True
+                        t.trigLepton = l
+                        break
+            if not passPair: return False
+            self.counters.counter('events').inc('pass lepTrackPair')
 
         self.counters.counter('events').inc('accepted events')
         return True


### PR DESCRIPTION
Requires https://github.com/CERN-PH-CMG/cmg-cmssw/pull/733 to be merged, or 
`git pull https://github.com/gpetruc/cmg-cmssw.git heppy_94X_TriggerMatchAnalyzer` 

One can run heppy or heppy_batch with `--option region=sr` for the signal region and  `--option region=cr1l` for the single-lepton control region (reminder: the shortcut `-o` can be used instead of `--option` in heppy but not in heppy_batch). 

I have also added some first set of MC, including some privately-produced Winos.

Other features added are:
* `--option run=...` in heppy or hepp_batch allows to specify what to run or submit`all`, `mc`, `data`, `sig`
* running heppy with `-o justSummary` just prints the summary table of number of events, jobs, etc. but without running anything.
